### PR TITLE
Fix manifests

### DIFF
--- a/bucket/extremetuxracer.json
+++ b/bucket/extremetuxracer.json
@@ -1,13 +1,12 @@
 {
-    "version": "0.8.3",
+    "version": "0.8.4",
     "description": "High-speed arctic racing game based on Tux Racer",
     "homepage": "https://sourceforge.net/projects/extremetuxracer/",
     "license": "GPL-2.0-or-later",
-    "depends": "extras/vcredist2015",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/extremetuxracer/releases/0.8.3/ExtremeTuxRacer_0.8.3_x64.msi",
-            "hash": "sha1:f35f85b85a66769010fc76b0b9fd32c04246ad1a"
+            "url": "https://sourceforge.net/projects/extremetuxracer/files/releases/0.8.4/ExtremeTuxRacer.msi",
+            "hash": "sha1:db2053a87f82ea236fd46146ba850e0f058019d7"
         }
     },
     "extract_dir": "PFiles\\Extreme TuxRacer",
@@ -17,13 +16,11 @@
             "Extreme Tux Racer"
         ]
     ],
-    "checkver": {
-        "regex": "ExtremeTuxRacer_([\\d.-]+)_x[\\d]{2}\\.msi"
-    },
+    "checkver": "sourceforge",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/extremetuxracer/releases/$version/ExtremeTuxRacer_$version_x64.msi"
+                "url": "https://sourceforge.net/projects/extremetuxracer/files/releases/$version/ExtremeTuxRacer.msi"
             }
         }
     }

--- a/bucket/gdsdecomp.json
+++ b/bucket/gdsdecomp.json
@@ -1,10 +1,10 @@
 {
-    "version": "0.9.1",
+    "version": "1.00-beta.3",
     "description": "Godot reverse engineering tools",
     "homepage": "https://github.com/GDRETools/gdsdecomp",
     "license": "MIT",
-    "url": "https://github.com/GDRETools/gdsdecomp/releases/download/v0.9.1/GDRE_tools-v0.9.1-windows.zip",
-    "hash": "b499086deb780a4ba81c52ba3ab41ed39269a22f93c1046b8e3e573971e192f5",
+    "url": "https://github.com/GDRETools/gdsdecomp/releases/download/v1.00-beta.3/GDRE_tools-v1.00-beta.3-windows.zip",
+    "hash": "ef4a8a034404d19ee86da42b5ecebe8918226fc931ce43d0e242ba7b99ff67f7",
     "bin": "gdre_tools.exe",
     "shortcuts": [
         [
@@ -12,7 +12,10 @@
             "gdsdecomp"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/GDRETools/gdsdecomp",
+        "regex": "/releases/tag/(?:v|V)?([\\w-.]+)"
+    },
     "autoupdate": {
         "url": "https://github.com/GDRETools/gdsdecomp/releases/download/v$version/GDRE_tools-v$version-windows.zip"
     }

--- a/bucket/infraarcana.json
+++ b/bucket/infraarcana.json
@@ -1,5 +1,5 @@
 {
-    "version": "20220407-3aee05d9",
+    "version": "23.0.0",
     "description": "A roguelike game set in the early 20th century",
     "homepage": "https://sites.google.com/site/infraarcana/home",
     "license": {
@@ -9,9 +9,9 @@
     "notes": "User data are stored in C:\\Users\\[USERNAME]\\AppData\\Roaming\\infra_arcana",
     "architecture": {
         "64bit": {
-            "url": "https://gitlab.com/martin-tornqvist/ia/-/jobs/2306331827/artifacts/download#/dl.zip",
-            "hash": "a897f0c3ba1ae7590fbc70e1a7a9611e92bff4dcb4b9ca1e56c5c0477bb01110",
-            "extract_dir": "ia-windows-x64-v21.0.1-3aee05d9-2022-04-07"
+            "url": "https://gitlab.com/martin-tornqvist/ia/-/jobs/artifacts/v23.0.0/download?job=build-windows",
+            "hash": "d11b5cb2c9afea6c2ae849c7d81f73f8d4a2f50ef5f7f4360a9e93f320aa1253",
+            "extract_dir": "ia_windows_x64_v23.0.0"
         }
     },
     "shortcuts": [
@@ -25,15 +25,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://gitlab.com/martin-tornqvist/ia/-/jobs",
-        "regex": "passed(?:.*\\n){4}.*(?<job>[0-9]{10})\">build-windows(?:.*\\n){13}.*\\/commit\\/[0-9a-f]{40}\">(?<commit>[0-9a-f]{8})<\\/a>(?:.*\\n){20}.*datetime=\"(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})",
-        "replace": "${year}${month}${day}-${commit}"
+        "regex": "Download v(?<version>[\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://gitlab.com/martin-tornqvist/ia/-/jobs/$matchJob/artifacts/download#/dl.zip",
-                "extract_dir": "ia-windows-x64-v21.0.1-$matchCommit-$matchYear-$matchMonth-$matchDay"
+                "url": "https://gitlab.com/martin-tornqvist/ia/-/jobs/artifacts/v$version/download?job=build-windows",
+                "extract_dir": "ia_windows_x64_v$version"
             }
         }
     }

--- a/bucket/lambdahack.json
+++ b/bucket/lambdahack.json
@@ -20,7 +20,10 @@
             "Lambda Hack"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "url": "https://api.github.com/repos/LambdaHack/LambdaHack/releases",
+        "regex": "LambdaHack_(?<version>[\\d.]+)_windows-x86_64\\.zip"
+    },
     "autoupdate": {
         "architecture": {
             "32bit": {

--- a/bucket/lzdoom.json
+++ b/bucket/lzdoom.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.88",
+    "version": "4.11.4",
     "description": "Legacy source port for Doom, Heretic, Hexen and more (based on GZDoom)",
     "homepage": "https://zdoom.org/",
     "license": "GPL-3.0-or-later",
@@ -10,12 +10,12 @@
     ],
     "architecture": {
         "32bit": {
-            "url": "https://github.com/drfrag666/gzdoom/releases/download/3.88/LZDoom_3.88_x86.zip",
-            "hash": "7bb5607a59f27a8095e59319b52fe9176911c19431b7267a0b1d119a039dab5f"
+            "url": "https://github.com/drfrag666/lzdoom/releases/download/l4.11.4/lzdoom-l4.11.4-x86.zip",
+            "hash": "af7a25e75f1a690103f519abc0d3deae999139657b2e4cd7fee155a0c52fc4c3"
         },
         "64bit": {
-            "url": "https://github.com/drfrag666/gzdoom/releases/download/3.88/LZDoom_3.88_x64.zip",
-            "hash": "331210c7b2d85080333e3e00140bd0119da58256fe1d142591b079ef4fe74fda"
+            "url": "https://github.com/drfrag666/lzdoom/releases/download/l4.11.4/lzdoom-l4.11.4-x64.zip",
+            "hash": "beb735fc95d9e5720de5083f35935fcf06d3eb6d9fdfb88c61d074370b5fda66"
         }
     },
     "pre_install": "New-Item -ItemType Directory -Force -Path $persist_dir\\..\\_doom | Out-Null",
@@ -30,15 +30,17 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/drfrag666/gzdoom"
+        "github": "https://github.com/drfrag666/lzdoom",
+        "regex": "/releases/tag/(?<prefix>[a-z]*)(?<version1>[\\d.]+)(?<version2>[a-z]?)",
+        "replace": "${version1}${version2}"
     },
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/drfrag666/gzdoom/releases/download/$version/LZDoom_$version_x86.zip"
+                "url": "https://github.com/drfrag666/lzdoom/releases/download/$matchPrefix$version/lzdoom-$matchPrefix$version-x86.zip"
             },
             "64bit": {
-                "url": "https://github.com/drfrag666/gzdoom/releases/download/$version/LZDoom_$version_x64.zip"
+                "url": "https://github.com/drfrag666/lzdoom/releases/download/$matchPrefix$version/lzdoom-$matchPrefix$version-x64.zip"
             }
         }
     }

--- a/bucket/mameui.json
+++ b/bucket/mameui.json
@@ -1,21 +1,20 @@
 {
-    "version": "nightly",
+    "version": "0.277.0",
     "description": "GUI frontend for MAME, the multi-purpose emulation framework",
-    "homepage": "http://www.mameui.info/",
+    "homepage": "https://messui.1emulation.com",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "http://www.mameui.info/MAMEUI.7z",
-            "extract_dir": "MAMEUI",
-            "bin": "mameui.exe",
-            "shortcuts": [
-                [
-                    "MAMEUI.exe",
-                    "MAMEUI"
-                ]
-            ]
+            "url": "https://messui.1emulation.com/mameui277.7z",
+            "hash": "70b2cf6934f4d105fd557a73268a815863d4d4cf735e5d7331cac8ddd088c60b"
         }
     },
+    "shortcuts": [
+        [
+            "mameui.exe",
+            "MAMEUI"
+        ]
+    ],
     "persist": [
         "cfg",
         "diff",
@@ -27,13 +26,12 @@
         "sta"
     ],
     "checkver": {
-        "regex": "MAMEUI v\\.([\\d]+) Download",
-        "replace": "0.${1}"
+        "regex": "MAMEUI64 ([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://www.mameui.info/MAMEUI.7z"
+                "url": "https://messui.1emulation.com/mameui$minorVersion.7z"
             }
         }
     }

--- a/bucket/openmsx-dev.json
+++ b/bucket/openmsx-dev.json
@@ -1,13 +1,13 @@
 {
-    "version": "19.1-450-g0dcc41318",
+    "version": "20.0-469-g3534a1d3c",
     "description": "Cycle-accurate MSX emulator (Development builds)",
     "homepage": "https://openmsx.fixato.net/",
     "license": "GPL-2.0",
     "notes": "User data are stored in C:\\Users\\[USERNAME]\\Documents\\openMSX",
     "architecture": {
         "64bit": {
-            "url": "https://openmsx.fixato.net/builds/windows/x64/openmsx-19.1-450-g0dcc41318-windows-vc-x64-bin.zip",
-            "hash": "e219e6d3ad8aae753e3c6f5729c0ed1c67a71e394c932afb0885e216446248d3"
+            "url": "https://vampier.net/openMSX/openmsx-20.0-469-g3534a1d3c-windows-vc-x64-bin.zip",
+            "hash": "80aadfe28b411be804d91541e3af2fa1ecb1029dffde72221e885299bdd47f8a"
         }
     },
     "bin": [
@@ -27,14 +27,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://openmsx.fixato.net/builds/windows/x64/",
-        "regex": "openmsx-(?<ver>[\\d.]+)-(?<build>[\\d]+)-g(?<commit>[\\da-f]{9})-windows-vc-x64-bin\\.zip",
-        "replace": "${ver}-${build}-g${commit}"
+        "url": "https://vampier.net/openMSX/",
+        "regex": "openmsx-(?<version>[\\w.-]+)-windows-vc-x64-bin.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://openmsx.fixato.net/builds/windows/x64/openmsx-$version-windows-vc-x64-bin.zip"
+                "url": "https://vampier.net/openMSX/openmsx-$version-windows-vc-x64-bin.zip"
             }
         }
     }

--- a/bucket/prboom-plus.json
+++ b/bucket/prboom-plus.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.6.2",
+    "version": "2.6.66",
     "description": "Enhanced, highly-compatible source port for Doom",
     "homepage": "http://prboom-plus.sourceforge.net/",
     "license": "GPL-2.0-or-later",
@@ -8,9 +8,13 @@
         "",
         "    $persist_dir\\..\\_doom"
     ],
-    "url": "https://github.com/coelckers/prboom-plus/releases/download/v2.6.2/prboom-plus-262-w32.zip",
-    "hash": "20313e00d8841a618e23e7c671d65870194bee634468fecd2f3697ac05f21476",
-    "extract_dir": "prboom-plus-262-w32",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/coelckers/prboom-plus/releases/download/v2.6.66/prboom-plus-2666-ucrt64.zip",
+            "hash": "9c8c2b021a57739e8428b599d80c25a6b95150084cb04a7e433877123b15b141"
+        }
+    },
+    "extract_dir": "prboom-plus-2666-ucrt64",
     "pre_install": "New-Item -ItemType Directory -Force -Path $persist_dir\\..\\_doom | Out-Null",
     "env_set": {
         "DOOMWADDIR": "$persist_dir\\..\\_doom"
@@ -53,10 +57,15 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/coelckers/prboom-plus"
+        "github": "https://github.com/coelckers/prboom-plus",
+        "regex": "releases/tag/v([\\d.]+[a-z]*)"
     },
     "autoupdate": {
-        "url": "https://github.com/coelckers/prboom-plus/releases/download/v$version/prboom-plus-$cleanVersion-w32.zip",
-        "extract_dir": "prboom-plus-$cleanVersion-w32"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/coelckers/prboom-plus/releases/download/v$version/prboom-plus-$cleanVersion-ucrt64.zip"
+            }
+        },
+        "extract_dir": "prboom-plus-$cleanVersion-ucrt64"
     }
 }

--- a/bucket/prismlauncher-qt5.json
+++ b/bucket/prismlauncher-qt5.json
@@ -70,7 +70,8 @@
         "prismlauncher.cfg"
     ],
     "checkver": {
-        "github": "https://github.com/PrismLauncher/PrismLauncher"
+        "url": "https://api.github.com/repos/PrismLauncher/PrismLauncher/releases",
+        "regex": "Windows-MSVC-Legacy-Portable-([\\d.]+)\\.zip"
     },
     "autoupdate": {
         "url": "https://github.com/PrismLauncher/PrismLauncher/releases/download/$version/PrismLauncher-Windows-MSVC-Legacy-Portable-$version.zip"

--- a/bucket/rbdoom-3-bfg.json
+++ b/bucket/rbdoom-3-bfg.json
@@ -1,5 +1,5 @@
 {
-    "version": "v1.4.0",
+    "version": "1.6.0",
     "description": "Source port for Doom 3: BFG Edition",
     "homepage": "https://github.com/RobertBeckebans/RBDOOM-3-BFG",
     "license": "https://github.com/RobertBeckebans/RBDOOM-3-BFG/blob/master/COPYING.txt",
@@ -12,8 +12,8 @@
         "",
         "https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe"
     ],
-    "url": "https://github.com/RobertBeckebans/RBDOOM-3-BFG/releases/download/v1.4.0/RBDOOM-3-BFG-1.4.0.9-lite-win64-20220306-git-f81a8c1.7z",
-    "hash": "c116eba68c0c2abc6bed8ef6343d62e4f00f2328b98c0fc5a56523166e540c87",
+    "url": "https://github.com/RobertBeckebans/RBDOOM-3-BFG/releases/download/v1.6.0/RBDOOM-3-BFG-1.6.0.22-full-win64-20250510-git-ba39ba6.7z",
+    "hash": "f1b9a325cede2a281ece7d10a1a8bc48ce760d12ae23e37c62308631a886abae",
     "shortcuts": [
         [
             "RBDoom3BFG.exe",
@@ -22,10 +22,10 @@
     ],
     "persist": "base",
     "checkver": {
-        "url": "https://github.com/RobertBeckebans/RBDOOM-3-BFG/releases/latest",
-        "regex": "/RobertBeckebans/RBDOOM-3-BFG/releases/download/([a-zA-Z\\d.\\-]+)/RBDOOM-3-BFG-(?<file>[a-zA-Z\\d.\\-]+)\\.7z"
+        "url": "https://api.github.com/repos/RobertBeckebans/RBDOOM-3-BFG/releases/latest",
+        "regex": "/RobertBeckebans/RBDOOM-3-BFG/releases/download/(?<prefix>v)?(?<version>[\\w.-]+)/RBDOOM-3-BFG-(?<file>[a-zA-Z\\d.\\-]+)\\.7z"
     },
     "autoupdate": {
-        "url": "https://github.com/RobertBeckebans/RBDOOM-3-BFG/releases/download/$version/RBDOOM-3-BFG-$matchFile.7z"
+        "url": "https://github.com/RobertBeckebans/RBDOOM-3-BFG/releases/download/$matchPrefix$version/RBDOOM-3-BFG-$matchFile.7z"
     }
 }

--- a/bucket/rimpy-pre-release.json
+++ b/bucket/rimpy-pre-release.json
@@ -17,8 +17,9 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/rimpy-custom/RimPy/tags",
-        "regex": "([\\d.]+)</a></h2>"
+        "url": "https://api.github.com/repos/rimpy-custom/RimPy/releases",
+        "jsonpath": "$..assets[?(@.name == 'RimPy_Windows.zip')].browser_download_url",
+        "regex": "releases/download/(?<version>[\\d.]+)/RimPy_Windows\\.zip"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/rimpy.json
+++ b/bucket/rimpy.json
@@ -15,7 +15,11 @@
             "RimPy"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "url": "https://api.github.com/repos/rimpy-custom/RimPy/releases",
+        "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name == 'RimPy_Windows.zip')].browser_download_url",
+        "regex": "releases/download/(?<version>[\\d.]+)/RimPy_Windows\\.zip"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/rvgl-launcher.json
+++ b/bucket/rvgl-launcher.json
@@ -1,15 +1,15 @@
 {
     "version": "0.1.23.1030a3",
-    "homepage": "https://www.revoltworld.net/dl/rvgllauncher/",
+    "homepage": "https://re-volt.gitlab.io/rvgl-launcher/",
     "description": "A cross-platform installer, launcher and package manager for the RVGL Re-Volt reimplementation",
     "license": "GPL-3.0-only",
     "architecture": {
         "32bit": {
-            "url": "https://rvgl.re-volt.io/downloads/rvgl_launcher_win32.zip",
+            "url": "https://rvgl.org/downloads/rvgl_launcher_win32.zip",
             "hash": "0220c7fc503f32dfedd4389510b89511d285efd268919f1272e39545bc7c7430"
         },
         "64bit": {
-            "url": "https://rvgl.re-volt.io/downloads/rvgl_launcher_win64.zip",
+            "url": "https://rvgl.org/downloads/rvgl_launcher_win64.zip",
             "hash": "77cc8f41357b47e557533966d59deec71f9dd4e9a6b3dbd576b42766302b73f9"
         }
     },
@@ -19,14 +19,25 @@
             "RVGL Launcher"
         ]
     ],
-    "checkver": "Version\\s+\\n\\s+<span\\sclass=\"badge\">([\\w.]+)</span>",
+    "checkver": {
+        "url": "https://rvgl.org/downloads/rvgl_launcher.json",
+        "jsonpath": "$.version"
+    },
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://rvgl.re-volt.io/downloads/rvgl_launcher_win32.zip"
+                "url": "https://rvgl.org/downloads/rvgl_launcher_win32.zip",
+                "hash": {
+                    "url": "https://rvgl.org/downloads/rvgl_launcher.json",
+                    "jsonpath": "$.win32.checksum"
+                }
             },
             "64bit": {
-                "url": "https://rvgl.re-volt.io/downloads/rvgl_launcher_win64.zip"
+                "url": "https://rvgl.org/downloads/rvgl_launcher_win64.zip",
+                "hash": {
+                    "url": "https://rvgl.org/downloads/rvgl_launcher.json",
+                    "jsonpath": "$.win64.checksum"
+                }
             }
         }
     }

--- a/bucket/stella.json
+++ b/bucket/stella.json
@@ -1,35 +1,24 @@
 {
-    "version": "6.7.1",
+    "version": "7.0",
     "description": "Multi-platform Atari 2600 VCS emulator",
     "homepage": "https://stella-emu.github.io/",
     "license": "GPL-2.0-only",
-    "url": "https://github.com/stella-emu/stella/releases/download/6.7.1/Stella-6.7.1-windows.zip",
-    "hash": "6781efff51aa28390b2f858a1e7b8b98111fad62bccede400c6e741b43a49099",
-    "architecture": {
-        "32bit": {
-            "shortcuts": [
-                [
-                    "32-bit/Stella.exe",
-                    "Stella"
-                ]
-            ]
-        },
-        "64bit": {
-            "shortcuts": [
-                [
-                    "64-bit/Stella.exe",
-                    "Stella"
-                ]
-            ]
-        }
-    },
-    "extract_dir": "Stella-6.7.1",
+    "url": "https://github.com/stella-emu/stella/releases/download/7.0/Stella-7.0c-windows.zip",
+    "hash": "44102ccf8af74b021cf143db346e561c5d6ed2a2e91d79ee6d3c99d7c42f4653",
+    "extract_dir": "Stella-7.0c",
+    "shortcuts": [
+        [
+            "Stella.exe",
+            "Stella"
+        ]
+    ],
     "persist": "config",
     "checkver": {
-        "github": "https://github.com/stella-emu/stella"
+        "url": "https://api.github.com/repos/stella-emu/stella/releases",
+        "regex": "releases/download/(?<version>[\\d.]+)/Stella-\\k<version>(?<postfix>\\w*)-windows.zip"
     },
     "autoupdate": {
-        "url": "https://github.com/stella-emu/stella/releases/download/$version/Stella-$version-windows.zip",
-        "extract_dir": "Stella-$version"
+        "url": "https://github.com/stella-emu/stella/releases/download/$version/Stella-$version$matchPostfix-windows.zip",
+        "extract_dir": "Stella-$version$matchPostfix"
     }
 }

--- a/bucket/tf2classic.json
+++ b/bucket/tf2classic.json
@@ -1,23 +1,19 @@
 {
-    "version": "2.1.5",
+    "version": "2.2.2",
     "license": "Freeware",
     "homepage": "https://tf2classic.com/",
     "description": "Team Fortress 2 Classic is a free Sourcemod that aims to re-imagine the 2008/2009 era of the original Team Fortress 2. New features range from weapons and maps to gamemodes such as VIP and Four-Team.",
     "url": "https://wiki.tf2classic.com/kachemak/tf2classic.zip",
-    "post_install": [
-        "New-Item -ItemType SymbolicLink -Path 'C:\\Program Files (x86)\\Steam\\steamapps\\sourcemods\\tf2classic' -Target \"$dir\""
-    ],
+    "hash": "e45a21e2d7ede9ae15162e2f0d8f6dd31d8922985d172288d9f8d0f25dc05635",
+    "post_install": "New-Item -ItemType SymbolicLink -Path 'C:\\Program Files (x86)\\Steam\\steamapps\\sourcemods\\tf2classic' -Target \"$dir\"",
     "checkver": {
         "url": "https://tf2classic.com/",
         "regex": "Game v([\\d.]+)"
     },
-    "pre_uninstall": [
-        "if ($cmd -eq \"uninstall\") { rm -r 'C:\\Program Files (x86)\\Steam\\steamapps\\sourcemods\\tf2classic' }"
-    ],
-    "notes": [
-        "To run TF2 Classic, you must have Source SDK Base 2013 Multiplayer installed. If you do not have it, follow this link: steam://install/243750"
-    ],
-    "persist": [
-        "cfg"
-    ]
+    "autoupdate": {
+        "url": "https://wiki.tf2classic.com/kachemak/tf2classic.zip"
+    },
+    "pre_uninstall": "if ($cmd -eq \"uninstall\") { rm -r 'C:\\Program Files (x86)\\Steam\\steamapps\\sourcemods\\tf2classic' }",
+    "notes": "To run TF2 Classic, you must have Source SDK Base 2013 Multiplayer installed. If you do not have it, follow this link: steam://install/243750",
+    "persist": "cfg"
 }

--- a/bucket/tome4.json
+++ b/bucket/tome4.json
@@ -1,11 +1,11 @@
 {
-    "version": "1.7.0",
+    "version": "1.7.6",
     "description": "Tales of Maj’Eyal (ToME) is a free, open source roguelike RPG, featuring tactical turn-based combat and advanced character building.",
     "homepage": "https://te4.org",
     "license": "GPL-3.0-only",
-    "url": "http://te4.org/dl/t-engine/t-engine4-windows-1.7.0.zip",
-    "hash": "76ac63f8682642015b4ac14af2b9caab1ffc6c8260a51ad34c26eccffaca3197",
-    "extract_dir": "t-engine4-windows-1.7.0",
+    "url": "https://te4.org/dl/t-engine/t-engine4-windows-1.7.6.zip",
+    "hash": "38dddcf9a09e3640b1195372763ade25187d0a840556614b72d9223d3fe97c8c",
+    "extract_dir": "t-engine4-windows-1.7.6",
     "bin": [
         [
             "t-engine.exe",
@@ -29,10 +29,10 @@
     "persist": "game\\addons",
     "checkver": {
         "url": "https://te4.org/download",
-        "re": "Tales of Maj'Eyal Installer (.*) for Windows"
+        "re": "Tales of Maj'Eyal ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "http://te4.org/dl/t-engine/t-engine4-windows-$version.zip",
+        "url": "https://te4.org/dl/t-engine/t-engine4-windows-$version.zip",
         "extract_dir": "t-engine4-windows-$version"
     }
 }

--- a/bucket/trenchbroom.json
+++ b/bucket/trenchbroom.json
@@ -1,11 +1,15 @@
 {
-    "version": "2024.2",
+    "version": "2025.3",
     "description": "Level editor for Quake-based games",
     "homepage": "https://kristianduske.com/trenchbroom/",
     "license": "GPL-3.0-or-later",
     "depends": "extras/vcredist2022",
-    "url": "https://github.com/kduske/TrenchBroom/releases/download/v2024.2/TrenchBroom-Win32-v2024.2-Release.7z",
-    "hash": "8e680c6eec4295ca1161edd521fcff7708f47853ded87cad99a72d322bd981a2",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/TrenchBroom/TrenchBroom/releases/download/v2025.3/TrenchBroom-Win64-AMD64-v2025.3-Release.zip",
+            "hash": "md5:43f01430ed6988d38ec33aef49cc1daa"
+        }
+    },
     "bin": "TrenchBroom.exe",
     "shortcuts": [
         [
@@ -17,6 +21,13 @@
         "github": "https://github.com/kduske/TrenchBroom"
     },
     "autoupdate": {
-        "url": "https://github.com/kduske/TrenchBroom/releases/download/v$version/TrenchBroom-Win32-v$version-Release.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/TrenchBroom/TrenchBroom/releases/download/v$version/TrenchBroom-Win64-AMD64-v$version-Release.zip",
+                "hash": {
+                    "url": "$url.md5"
+                }
+            }
+        }
     }
 }

--- a/bucket/umod.json
+++ b/bucket/umod.json
@@ -1,5 +1,5 @@
 {
-    "version": "v2_r53",
+    "version": "2_r53",
     "description": "uMod (Universal Modding Engine, earlier OpenTexMod) is an utility to find, save and modify textures that supports original TexMod *.tpf mods",
     "license": "GPL-3.0-only",
     "homepage": "https://code.google.com/archive/p/texmod/",
@@ -16,10 +16,10 @@
         ]
     ],
     "checkver": {
-        "url": "https://code.google.com/archive/p/texmod/downloads",
-        "regex": "uMod(_alpha|_beta)?_(?<version>v(\\d+)_r(\\d+))"
+        "url": "https://storage.googleapis.com/storage/v1/b/google-code-archive/o/v2%2Fcode.google.com%2Ftexmod%2Fdownloads-page-1.json?alt=media&stripTrailingSlashes=false",
+        "regex": "uMod(?<prefix>(?:_alpha|_beta)?)_v(?<version>\\d+_r\\d+)"
     },
     "autoupdate": {
-        "url": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/texmod/uMod_alpha_v$version.zip"
+        "url": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/texmod/uMod$matchPrefix_v$version.zip"
     }
 }

--- a/bucket/yquake2.json
+++ b/bucket/yquake2.json
@@ -1,5 +1,5 @@
 {
-    "version": "8.41",
+    "version": "8.51",
     "description": "Conservative Quake 2 source port focused on singleplayer and cooperative gameplay",
     "homepage": "https://www.yamagi.org/quake2/",
     "license": "GPL-2.0-or-later",
@@ -33,9 +33,9 @@
     "suggest": {
         "Vulkan renderer": "yquake2-ref-vk"
     },
-    "url": "https://deponie.yamagi.org/quake2/windows/quake2-8.41.zip",
-    "hash": "1a2f083cf91b933ef33b2c020b24cc81a7a2ac09dc475ffbd40195f49b92182a",
-    "extract_dir": "quake2-8.41",
+    "url": "https://deponie.yamagi.org/quake2/windows/quake2-8.51.zip",
+    "hash": "7cf0f75b25432ca89c10463818bc8d3633240353645132b622dee32ab93759ad",
+    "extract_dir": "quake2-8.51",
     "installer": {
         "script": [
             "$persistFolders = @(",
@@ -86,13 +86,10 @@
         "zaero"
     ],
     "checkver": {
-        "url": "https://deponie.yamagi.org/quake2/windows",
-        "regex": "(?'ver'\\d\\.\\d{2}[a-z]?)",
-        "replace": "${ver}",
-        "reverse": true
+        "regex": "Yamagi Quake II, Version\\n(?<version>[\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://deponie.yamagi.org/quake2/windows/quake2-$matchVer.zip",
-        "extract_dir": "quake2-$matchVer"
+        "url": "https://deponie.yamagi.org/quake2/windows/quake2-$version.zip",
+        "extract_dir": "quake2-$version"
     }
 }


### PR DESCRIPTION
This PR makes the following changes:
- `prismlauncher-qt5@7.2`: fix checkver.
- `rvgl-launcher@0.1.23.1030a3`: fix checkver, fix autoupdate.
- `tf2classic@2_r53`: fix checkver, fix autoupdate.
- `tf2classic`: Update to version 2.2.2, add hash, fix checkver, fix autoupdate.
- `mameui`: Update to version 0.277.0, fix checkver, fix autoupdate.
- `rbdoom-3-bfg`: Update to version 1.6.0, fix checkver, fix autoupdate.
- `prboom-plus`: Update to version 2.6.66, fix arch, fix checkver, fix autoupdate.
- `lzdoom`: Update to version 4.11.4, fix checkver, fix autoupdate.
- `openmsx-dev`: Update to version 20.0-469-g3534a1d3c, fix checkver, fix autoupdate.
- `stella`: Update to version 7.0, fix shortcuts, fix checkver, fix autoupdate.
- `tome4`: Update to version 1.7.6, fix checkver.
- `rimpy-pre-release@1.2.6.28`: Fix checkver.
- `rimpy@1.2.6.28`: Fix checkver.
- `trenchbroom`: Update to version 2025.3, fix autoupdate.
- `yquake2`: Update to version 8.51, fix checkver, fix autoupdate.
- `infraarcana`: Update to version 23.0.0, fix checkver, fix autoupdate.
- `lambdahack@0.11.0.0`: Fix checkver.
- `gdsdecomp`: Update to version 1.00-beta.3, fix checkver.
- `extremetuxracer`: Update to version 0.8.4, fix checkver, fix autoupdate, remove depends.