### PR TITLE
unciv: Update to version 4.16.13-patch1, fix checkver

### DIFF
--- a/bucket/unciv.json
+++ b/bucket/unciv.json
@@ -1,13 +1,13 @@
 {
-    "version": "4.16.13",
+    "version": "4.16.13-patch1",
     "homepage": "https://github.com/yairm210/UnCiv",
     "description": "Open source, mod-friendly Android + Desktop remake of Civ V, made with LibGDX",
     "license": "MPL-2.0",
     "suggest": {
         "Java Runtime Environment": "java/temurin-jre"
     },
-    "url": "https://github.com/yairm210/Unciv/releases/download/4.16.13/Unciv-Windows64.zip",
-    "hash": "2c6614a6273a9a2ce5ee92ee696a10ebe1cd79a2a459ee7264d272068b9dc6e7",
+    "url": "https://github.com/yairm210/Unciv/releases/download/4.16.13-patch1/Unciv-Windows64.zip",
+    "hash": "9b8c703143a06df80f61acbf80a658fc607a4bf6316011d0b5e764e7becc4ac1",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\GameSettings.json\")) {",
         "New-Item \"$dir\\GameSettings.json\" -Value '{resolution:1200x800,windowState:{width:1920,height:1080},isFreshlyCreated:true,multiplayer:{userId:},version:1}' | Out-Null",
@@ -25,7 +25,8 @@
         "SaveFiles"
     ],
     "checkver": {
-        "github": "https://github.com/yairm210/UnCiv"
+        "url": "https://api.github.com/repos/yairm210/UnCiv/releases",
+        "jsonpath": "$[?(@.prerelease == false && @.assets[?(@.name == 'Unciv-Windows64.zip')])].tag_name"
     },
     "autoupdate": {
         "url": "https://github.com/yairm210/Unciv/releases/download/$version/Unciv-Windows64.zip"


### PR DESCRIPTION
This PR makes the following changes:
- `unciv`: Update to version 4.16.13-patch1, fix checkver.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).