### PR TITLE
modboy@3.11: Fix checkver, fix autoupdate

### DIFF
--- a/bucket/modboy.json
+++ b/bucket/modboy.json
@@ -23,7 +23,7 @@
     "checkver": {
         "script": [
             "$userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36'",
-            "$getData = ((Invoke-RestMethod 'https://gamebanana.com/apiv10/Tool/6321/Updates' -UserAgent $userAgent)._aRecords)[0]",
+            "$getData = ((Invoke-RestMethod 'https://gamebanana.com/apiv11/Tool/6321/Updates' -UserAgent $userAgent)._aRecords)[0]",
             "$getFile = $getData._aFiles._sFile",
             "($getData._sName) -match 'v([\\d.]+)' | Out-Null; $getVersion = $Matches[1]",
             "Write-Output \"$getFile, $getVersion\""
@@ -34,7 +34,7 @@
         "url": "https://files.gamebanana.com/tools/$matchFile",
         "hash": {
             "type": "md5",
-            "url": "https://gamebanana.com/apiv10/Tool/6321/Updates",
+            "url": "https://gamebanana.com/apiv11/Tool/6321/Updates",
             "mode": "json",
             "jsonpath": "$._aRecords[0]._aFiles[0]._sMd5Checksum",
             "find": "$md5"


### PR DESCRIPTION
https://github.com/Calinou/scoop-games/actions/runs/15623733818/job/44013968223

> InvalidOperation: 
> Line |
>    2 |  $getData = ((Invoke-RestMethod 'https://gamebanana.com/apiv10/Tool/63 …
>      |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>      | Cannot index into a null array.
> modboy: couldn't match '(?<File>[\w_]+\.exe),\s([\d.]+)' in the output of script

This PR makes the following changes:
- `modboy@3.11`: Fix checkver, fix autoupdate.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).
