### PR TITLE
tf2-hud-editor: Update to version 4.0, fix autoupdate, fix shortcuts

### DIFF
--- a/bucket/tf2-hud-editor.json
+++ b/bucket/tf2-hud-editor.json
@@ -1,18 +1,18 @@
 {
-    "version": "3.5",
+    "version": "4.0",
     "description": "Install and customize your favorite custom Team Fortress 2 HUDs",
     "homepage": "https://criticalflaw.ca/TF2HUD.Editor",
     "license": "MIT",
     "notes": ".NET 8.0 Runtime is required.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/3.5/tf2hud-editor-3.5.zip",
-            "hash": "29a0b9019ab17bb1808ba496fa98da43544201d86d1879002c9d800ddfae304e"
+            "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/4.0/tf2hud-editor-win64.zip",
+            "hash": "7d444f8df6704b993e4193453cdf63b42e547fd9cc2058d393ffa1452b9c8c1c"
         }
     },
     "shortcuts": [
         [
-            "TF2HUD.Editor.exe",
+            "HUDEditor.exe",
             "TF2 HUD Editor"
         ]
     ],
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/$version/tf2hud-editor-$version.zip"
+                "url": "https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/$version/tf2hud-editor-win64.zip"
             }
         }
     }


### PR DESCRIPTION
This PR makes the following changes:
- `tf2-hud-editor`: Update to version 4.0, fix autoupdate, fix shortcuts.

- [x] I have read the [Contributing Guide](https://github.com/Calinou/scoop-games/blob/master/CONTRIBUTING.md).